### PR TITLE
Force 302 redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,4 @@
   from = "/"
   to = "/api/"
   status = 302
+  force = true


### PR DESCRIPTION
Follow-up fix after Netlify fixed a bug in their system. 

See: https://community.netlify.com/t/changed-behavior-in-redirects/10084